### PR TITLE
fix bui-switch props bug

### DIFF
--- a/src/components/bui-switch.vue
+++ b/src/components/bui-switch.vue
@@ -17,15 +17,16 @@
             "title": {      //文本
                 type: String
             },
-            "checked": {    //默认值为 false，表明按钮是否开启 is on or not.
-                type: Boolean,
-                default: false
-            },
             "disabled": {   //默认值为 false，表明是否激活按钮
                 type: Boolean,
                 default: false
             }
 
+        },
+        data: function () {
+            return {
+                checked : false, //默认值为 false，表明按钮是否开启 is on or not.
+            }
         },
         methods: {
             "onchange": function (event) {


### PR DESCRIPTION
fix bui-switch props bug

error msg 
Avoid mutating a prop directly since the value will be overwritten whenever the parent component re-renders. Instead, use a data or computed property based on the prop's value.